### PR TITLE
Convert ackermann_msgs to build with colcon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(ackermann_msgs)
 
-find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
-# We want boost/format.hpp, which isn't in its own component.
-find_package(Boost REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
 
-add_message_files(
-  DIRECTORY msg
-  FILES AckermannDrive.msg AckermannDriveStamped.msg)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/AckermannDrive.msg"
+  "msg/AckermannDriveStamped.msg"
+  DEPENDENCIES std_msgs
+)
 
-generate_messages(DEPENDENCIES std_msgs)
+ament_export_dependencies(rosidl_default_runtime)
 
-catkin_package(
-  CATKIN_DEPENDS message_runtime std_msgs
-  DEPENDS Boost)
+ament_package()

--- a/README.rst
+++ b/README.rst
@@ -6,5 +6,12 @@ was defined by the ROS `Ackermann steering group`_.
 
 ROS documentation: http://www.ros.org/wiki/ackermann_msgs
 
+Building
+--------
+
+Use `colcon` to build this package::
+
+  colcon build --packages-select ackermann_msgs
+
 .. _Ackermann steering: http://en.wikipedia.org/wiki/Ackermann_steering_geometry
 .. _Ackermann steering group: http://www.ros.org/wiki/Ackermann%20Group

--- a/msg/AckermannDriveStamped.msg
+++ b/msg/AckermannDriveStamped.msg
@@ -1,5 +1,5 @@
 ## Time stamped drive command for robots with Ackermann steering.
 #  $Id$
 
-Header          header
+std_msgs/msg/Header header
 AckermannDrive  drive

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="3">
   <name>ackermann_msgs</name>
   <version>1.0.2</version>
   <description>
@@ -12,15 +13,13 @@
   <url type="repository">https://github.com/ros-drivers/ackermann_msgs.git</url>
   <url type="bugtracker">https://github.com/ros-drivers/ackermann_msgs/issues</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>message_runtime</run_depend>
-  <run_depend>std_msgs</run_depend>
-  
-  <export>
-    <architecture_independent/>
-  </export>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 </package>


### PR DESCRIPTION
## Summary
- switch to `ament_cmake` so the package can be built with `colcon`
- document how to build using `colcon`
- fix `AckermannDriveStamped` to reference `std_msgs` explicitly

## Testing
- `colcon build --packages-select ackermann_msgs` *(fails: could not find `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_687ccee6f3608324a155631764ec0504